### PR TITLE
修复反序列化到对象大小超出范围

### DIFF
--- a/src/main/java/me/xuxiaoxiao/chatapi/qq/protocol/ResultGetGroupNameListMask.java
+++ b/src/main/java/me/xuxiaoxiao/chatapi/qq/protocol/ResultGetGroupNameListMask.java
@@ -33,12 +33,12 @@ public class ResultGetGroupNameListMask {
         public long gid;
         public long code;
         public String name;
-        public int flag;
+        public long flag;
     }
 
     public static class GMask {
         public long gid;
-        public int mask;
+        public long mask;
     }
 
     public static class GMark {


### PR DESCRIPTION
public intflag;
public int mask;
执行 方法：get_group_name_list_mask2
QQTools.GSON.fromJson(XTools.http(httpOption, request).string(), new TypeToken<BaseRsp<ResultGetGroupNameListMask>>() {
        }.getType());
时反序列化失败。